### PR TITLE
Add the option to let the circuitry client delete messages manually

### DIFF
--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -151,7 +151,7 @@ module Circuitry
       change_message_visibility(message) if ignore_visibility_timeout
       logger.error("Error processing message #{message.id}: #{e}")
 
-      error_handler.call(e)
+      error_handler.call(e) if error_handler
     end
 
     def handle_message_with_middleware(message, &block)

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -132,8 +132,7 @@ module Circuitry
     end
 
     def process_messages_synchronously(messages, &block)
-      #messages.each { |message| process_message(message, &block) }
-      messages.each { |message| process_message_unsafely(message, &block) }
+      messages.each { |message| process_message(message, &block) }
     end
 
     def process_message(message, &block)
@@ -150,16 +149,6 @@ module Circuitry
       change_message_visibility(message) if ignore_visibility_timeout
       logger.error("Error processing message #{message.id}: #{e}")
       error_handler.call(e) if error_handler
-    end
-
-    def process_message_unsafely(message, &block)
-      message = Message.new(message)
-
-      logger.info("Processing message #{message.id}")
-
-      handled = handle_message_with_middleware(message, &block)
-
-      logger.info("Ignoring duplicate message #{message.id}") unless handled
     end
 
     def handle_message_with_middleware(message, &block)

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -69,6 +69,11 @@ module Circuitry
       Circuitry.subscriber_config.async_strategy
     end
 
+    def change_message_visibility(message, timeout = 0)
+      logger.info("Retrying message now by making the 'visiblity_timeout' #{timeout} seconds for message #{message.id}")
+      sqs.change_message_visibility(queue_url: queue, receipt_handle: message.receipt_handle, visibility_timeout: timeout)
+    end
+
     protected
 
     attr_writer :queue, :timeout, :wait_time, :batch_size, :ignore_visibility_timeout, :auto_delete
@@ -83,11 +88,6 @@ module Circuitry
               end
 
       @lock = value
-    end
-
-    def change_message_visibility(message, timeout = 0)
-      logger.info("Retrying message now by making the 'visiblity_timeout' #{timeout} seconds for message #{message.id}")
-      sqs.change_message_visibility(queue_url: queue, receipt_handle: message.receipt_handle, visibility_timeout: timeout)
     end
 
     private

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -128,7 +128,8 @@ module Circuitry
     end
 
     def process_messages_synchronously(messages, &block)
-      messages.each { |message| process_message(message, &block) }
+      #messages.each { |message| process_message(message, &block) }
+      messages.each { |message| process_message_unsafely(message, &block) }
     end
 
     def process_message(message, &block)
@@ -145,6 +146,16 @@ module Circuitry
       change_message_visibility(message) if ignore_visibility_timeout
       logger.error("Error processing message #{message.id}: #{e}")
       error_handler.call(e) if error_handler
+    end
+
+    def process_message_unsafely(message, &block)
+      message = Message.new(message)
+
+      logger.info("Processing message #{message.id}")
+
+      handled = handle_message_with_middleware(message, &block)
+
+      logger.info("Ignoring duplicate message #{message.id}") unless handled
     end
 
     def handle_message_with_middleware(message, &block)

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -22,7 +22,6 @@ module Circuitry
       batch_size: 10,
       ignore_visibility_timeout: false,
       auto_delete: true,
-      before_message: lambda {},
     }.freeze
 
     CONNECTION_ERRORS = [
@@ -181,7 +180,7 @@ module Circuitry
     # http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/
     def handle_message(message, &block)
       Timeout.timeout(timeout) do
-        before_message.call(message)
+        before_message.call(message) if before_message
         if auto_delete
           block.call(message.body, message.topic.name)
         else

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -135,20 +135,9 @@ RSpec.describe Circuitry::Subscriber, type: :model do
               double('Aws::SQS::Types::Message', message_id: 'one', receipt_handle: 'delete-one', body: { 'Message' => 'Foo'.to_json, 'TopicArn' => 'arn:aws:sns:us-east-1:123456789012:test-event-task-changed' }.to_json)
             end
 
-            describe 'when never calling delete' do
-              it 'does not delete the messages' do
-                subject.subscribe(&block)
-                expect(mock_sqs).to_not have_received(:delete_message).with(queue_url: queue, receipt_handle: 'delete-one')
-              end
-            end
-
-            describe 'when calling delete in the handler' do
-              let(:block) { ->(_, _, delete) { delete.call } }
-
-              it 'deletes the message' do
-                subject.subscribe(&block)
-                expect(mock_sqs).to have_received(:delete_message).with(queue_url: queue, receipt_handle: 'delete-one')
-              end
+            it 'does not delete the messages' do
+              subject.subscribe(&block)
+              expect(mock_sqs).to_not have_received(:delete_message).with(queue_url: queue, receipt_handle: 'delete-one')
             end
           end
 

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe Circuitry::Subscriber, type: :model do
             end
           end
 
-          describe 'when using async_delete' do
-            let(:options) { { async_delete: true } }
+          describe 'when using auto_delete' do
+            let(:options) { { auto_delete: false } }
             let(:messages) do
               double('Aws::SQS::Types::Message', message_id: 'one', receipt_handle: 'delete-one', body: { 'Message' => 'Foo'.to_json, 'TopicArn' => 'arn:aws:sns:us-east-1:123456789012:test-event-task-changed' }.to_json)
             end

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -314,6 +314,36 @@ RSpec.describe Circuitry::Subscriber, type: :model do
 
           it_behaves_like 'a valid subscribe request'
         end
+
+        describe 'before_message' do
+          let(:messages) {
+            double('Aws::SQS::Types::Message', message_id: 'one', receipt_handle: 'delete-one', body: { 'Message' => 'Foo'.to_json, 'TopicArn' => 'arn:aws:sns:us-east-1:123456789012:test-event-task-changed' }.to_json)
+          }
+          let(:options) { { before_message: before_message } }
+
+          let(:before_message) do
+            lambda do |_message|
+              expect(@expected_messages).to eq([])
+              @expected_messages << 'before_message was called'
+            end
+          end
+
+          let(:block) do
+            ->(_, _) do
+              expect(@expected_messages).to eq(['before_message was called'])
+              @expected_messages << 'subscribe block was called'
+            end
+          end
+
+          before do
+            @expected_messages = []
+          end
+
+          it 'calls the before_message handler before processing the messages' do
+            subject.subscribe(&block)
+            expect(@expected_messages).to eq(['before_message was called', 'subscribe block was called'])
+          end
+        end
       end
 
       describe 'when AWS credentials are not set' do

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Circuitry::Subscriber, type: :model do
             end
           end
 
-          describe 'when using auto_delete' do
+          describe 'when disabling auto_delete' do
             let(:options) { { auto_delete: false } }
             let(:messages) do
               double('Aws::SQS::Types::Message', message_id: 'one', receipt_handle: 'delete-one', body: { 'Message' => 'Foo'.to_json, 'TopicArn' => 'arn:aws:sns:us-east-1:123456789012:test-event-task-changed' }.to_json)


### PR DESCRIPTION
When specifying the auto_delete=false option to circuitry, a third argument will be passed into the handler and messages will no longer be deleted automatically.

`call` that lambda maybe if you want to delete the message.