### PR TITLE
Less noisy info logging

### DIFF
--- a/lib/circuitry/publisher.rb
+++ b/lib/circuitry/publisher.rb
@@ -54,7 +54,7 @@ module Circuitry
         # TODO: Don't use ruby timeout.
         # http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/
         Timeout.timeout(timeout) do
-          logger.info("Publishing message to #{topic_name}")
+          logger.debug("Publishing message to #{topic_name}")
 
           handler = ->(error, attempt_number, _total_delay) do
             logger.warn("Error publishing attempt ##{attempt_number}: #{error.class} (#{error.message}); retrying...")

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -186,7 +186,7 @@ module Circuitry
     end
 
     def delete_message(message)
-      logger.info("Removing message #{message.id} from queue")
+      logger.debug("Removing message #{message.id} from queue")
       sqs.delete_message(queue_url: queue, receipt_handle: message.receipt_handle)
     end
 

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -133,7 +133,7 @@ module Circuitry
     def process_message(message, &block)
       message = Message.new(message)
 
-      logger.info("Processing message #{message.id}")
+      logger.debug("Processing message #{message.id}")
 
       handled = try_with_lock(message.id) do
         handle_message_with_middleware(message, &block)


### PR DESCRIPTION
Move per-message logging to the debug level where it belongs.