### PR TITLE
Handle sigterm and sigint

### DIFF
--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -94,13 +94,13 @@ module Circuitry
     def trap_signals
       trap('SIGINT') do
         logger.info({"message" => "SIGINT_RECEIVED_JSON"}.to_json)
-        logger.info({"message" => "SIGINT_RECEIVED"}.to_json)
+        logger.info({"message" => "SIGINT_RECEIVED"})
         unsubscribe_from_queue
       end
 
       trap('SIGTERM') do
         logger.info({"message" => "SIGTERM_RECEIVED_JSON"}.to_json)
-        logger.info({"message" => "SIGTERM_RECEIVED"}.to_json)
+        logger.info({"message" => "SIGTERM_RECEIVED"})
         unsubscribe_from_queue
       end
     end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -105,7 +105,6 @@ module Circuitry
       if subscribed?
         Thread.new {
           logger.info('Interrupt received, unsubscribing from queue...')
-          logger.info({messages: 'SIGNAL_INTERRUPT_JSON'}.to_json)
         }
         self.subscribed = false
       end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -105,7 +105,6 @@ module Circuitry
       if subscribed?
         Thread.new {
           logger.info('Interrupt received, unsubscribing from queue...')
-          logger.info({messages: 'SIGNAL_INTERRUPT'})
           logger.info({messages: 'SIGNAL_INTERRUPT_JSON'}.to_json)
         }
         self.subscribed = false

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -105,6 +105,8 @@ module Circuitry
       if subscribed?
         Thread.new {
           logger.info('Interrupt received, unsubscribing from queue...')
+          logger.info({messages: 'SIGNAL_INTERRUPT'})
+          logger.info({messages: 'SIGNAL_INTERRUPT_JSON'}.to_json)
         }
         self.subscribed = false
       end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -93,10 +93,14 @@ module Circuitry
 
     def trap_signals
       trap('SIGINT') do
+        logger.info({"message" => "SIGINT_RECEIVED_JSON"}.to_json)
+        logger.info({"message" => "SIGINT_RECEIVED"}.to_json)
         unsubscribe_from_queue
       end
 
       trap('SIGTERM') do
+        logger.info({"message" => "SIGTERM_RECEIVED_JSON"}.to_json)
+        logger.info({"message" => "SIGTERM_RECEIVED"}.to_json)
         unsubscribe_from_queue
       end
     end
@@ -104,6 +108,7 @@ module Circuitry
     def unsubscribe_from_queue
       if subscribed?
         Thread.new {
+          logger.info({"message" => "SIGNAL_INTERRUPTION"})
           logger.info('Interrupt received, unsubscribing from queue...')
         }
         self.subscribed = false

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -93,14 +93,10 @@ module Circuitry
 
     def trap_signals
       trap('SIGINT') do
-        logger.info({"message" => "SIGINT_RECEIVED_JSON"}.to_json)
-        logger.info({"message" => "SIGINT_RECEIVED"})
         unsubscribe_from_queue
       end
 
       trap('SIGTERM') do
-        logger.info({"message" => "SIGTERM_RECEIVED_JSON"}.to_json)
-        logger.info({"message" => "SIGTERM_RECEIVED"})
         unsubscribe_from_queue
       end
     end
@@ -108,7 +104,6 @@ module Circuitry
     def unsubscribe_from_queue
       if subscribed?
         Thread.new {
-          logger.info({"message" => "SIGNAL_INTERRUPTION"})
           logger.info('Interrupt received, unsubscribing from queue...')
         }
         self.subscribed = false

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -103,7 +103,11 @@ module Circuitry
 
     def unsubscribe_from_queue
       if subscribed?
-        Thread.new { logger.info('Interrupt received, unsubscribing from queue...') }
+        p "SIGINT OR SIGTERM RECEIVED UNSUBSCRIBING FROM QUEUE"
+        Thread.new {
+          logger.info('Interrupt received, unsubscribing from queue...')
+          p 'Interrupt received, unsubscribing from queue...'
+        }
         self.subscribed = false
       end
     end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -103,10 +103,9 @@ module Circuitry
 
     def unsubscribe_from_queue
       if subscribed?
-        p "SIGINT OR SIGTERM RECEIVED UNSUBSCRIBING FROM QUEUE"
+        raise StandardError.new("SIGINT_OR_SIGTERM_UNSUBSCRIBING_FROM_QUEUE")
         Thread.new {
           logger.info('Interrupt received, unsubscribing from queue...')
-          p 'Interrupt received, unsubscribing from queue...'
         }
         self.subscribed = false
       end

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -93,10 +93,18 @@ module Circuitry
 
     def trap_signals
       trap('SIGINT') do
-        if subscribed?
-          Thread.new { logger.info('Interrupt received, unsubscribing from queue...') }
-          self.subscribed = false
-        end
+        unsubscribe_from_queue
+      end
+
+      trap('SIGTERM') do
+        unsubscribe_from_queue
+      end
+    end
+
+    def unsubscribe_from_queue
+      if subscribed?
+        Thread.new { logger.info('Interrupt received, unsubscribing from queue...') }
+        self.subscribed = false
       end
     end
 

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -103,7 +103,6 @@ module Circuitry
 
     def unsubscribe_from_queue
       if subscribed?
-        raise StandardError.new("SIGINT_OR_SIGTERM_UNSUBSCRIBING_FROM_QUEUE")
         Thread.new {
           logger.info('Interrupt received, unsubscribing from queue...')
         }


### PR DESCRIPTION
Unsubscribe from queues upon receiving either sigints or sigterms.
We know that kubernetes sends a sigterm and we want that to be handled in the same way as the sigint.