### PR TITLE
Allow Messages Directly From SQS

### DIFF
--- a/lib/circuitry/message.rb
+++ b/lib/circuitry/message.rb
@@ -18,7 +18,7 @@ module Circuitry
     end
 
     def topic
-      @topic ||= Topic.new(context['TopicArn'])
+      @topic ||= Topic.new(context['TopicArn']) if context['TopicArn']
     end
 
     def id

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -157,7 +157,7 @@ module Circuitry
     end
 
     def handle_message_with_middleware(message, &block)
-      middleware.invoke(message.topic.name, message.body) do
+      middleware.invoke(message.topic&.name, message.body) do
         handle_message(message, &block)
         delete_message(message)
       end
@@ -183,7 +183,7 @@ module Circuitry
     # http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/
     def handle_message(message, &block)
       Timeout.timeout(timeout) do
-        block.call(message.body, message.topic.name)
+        block.call(message.body, message.topic&.name)
       end
     rescue => e
       logger.error("Error handling message #{message.id}: #{e}")

--- a/spec/circuitry/message_spec.rb
+++ b/spec/circuitry/message_spec.rb
@@ -17,4 +17,10 @@ RSpec.describe Circuitry::Message, type: :model do
   its(:body) { is_expected.to eq body }
   its(:topic) { is_expected.to eq Circuitry::Topic.new(arn) }
   its(:receipt_handle) { is_expected.to eq handle }
+
+  context 'with no TopicArn (the message was not from a SNS<->SQS subscription, it was from SQS directly)' do
+    let(:context) { { 'Message' => body.to_json } }
+
+    its(:topic) { is_expected.to eq nil }
+  end
 end

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -256,6 +256,17 @@ RSpec.describe Circuitry::Subscriber, type: :model do
               end
             end
           end
+
+          context 'with no TopicArn (the message was not from a SNS<->SQS subscription, it was from SQS directly)' do
+            let(:messages) do
+              double('Aws::SQS::Types::Message', message_id: 'one', receipt_handle: 'delete-one', body: { 'Message' => 'Foo'.to_json }.to_json)
+            end
+
+            it 'processes the message' do
+              expect(block).to receive(:call).with('Foo', nil)
+              subject.subscribe(&block)
+            end
+          end
         end
 
         describe 'synchronously' do


### PR DESCRIPTION
This allows circuitry to handle messages that come directly from SQS instead of going through SNS.
We do this by making SNS ARNs optional.