### PR TITLE
Batch delete messages when they were filtered out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Circuitry 3.6.0 (July 28, 2021)
+
+* Filter callback option now deletes excluded messages from the SQS queue *Ada Ebling, Cesar Palafox*
+
+## Circuitry 3.5.0 (July 12, 2021)
+
+* Adds an option for a filter callback that excludes messages before processing *Ada Ebling, Cesar Palafox*
+
 ## Circuitry 3.4.0 Sep 16, 2020)
 
 * Adds an option for publisher and subscriber configs to override the AWS client options. *wahlg*

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -121,13 +121,13 @@ module Circuitry
       poller.poll(max_number_of_messages: batch_size, wait_time_seconds: wait_time, skip_delete: true) do |messages|
         messages = message_parser(messages)
         filtered_messages = filter_messages(messages)
-        delete_invalid_messages(messages, filtered_messages)
+        delete_excluded_messages(messages, filtered_messages)
         process_messages(filtered_messages, &block)
         Circuitry.flush
       end
     end
 
-    def delete_invalid_messages(unfiltered_messages, filtered_messages)
+    def delete_excluded_messages(unfiltered_messages, filtered_messages)
       messages_to_delete_from_queue = unfiltered_messages - filtered_messages
       return if messages_to_delete_from_queue.empty?
       delete_message_batch(messages_to_delete_from_queue)

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -119,16 +119,13 @@ module Circuitry
       end
 
       poller.poll(max_number_of_messages: batch_size, wait_time_seconds: wait_time, skip_delete: true) do |messages|
-        messages = parse_and_filter_messages(messages)
-        process_messages(messages, &block)
+        messages = message_parser(messages)
+        filtered_messages = filter_messages(messages)
+        process_messages(filtered_messages, &block)
         Circuitry.flush
       end
     end
 
-    def parse_and_filter_messages(messages)
-      filter_messages(
-        message_parser(messages)
-      )
     end
 
     def message_parser(messages)

--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -121,11 +121,16 @@ module Circuitry
       poller.poll(max_number_of_messages: batch_size, wait_time_seconds: wait_time, skip_delete: true) do |messages|
         messages = message_parser(messages)
         filtered_messages = filter_messages(messages)
+        delete_invalid_messages(messages, filtered_messages)
         process_messages(filtered_messages, &block)
         Circuitry.flush
       end
     end
 
+    def delete_invalid_messages(unfiltered_messages, filtered_messages)
+      messages_to_delete_from_queue = unfiltered_messages - filtered_messages
+      return if messages_to_delete_from_queue.empty?
+      delete_message_batch(messages_to_delete_from_queue)
     end
 
     def message_parser(messages)
@@ -209,6 +214,29 @@ module Circuitry
     def delete_message(message)
       logger.debug("Removing message #{message.id} from queue")
       sqs.delete_message(queue_url: queue, receipt_handle: message.receipt_handle)
+    end
+
+    def delete_message_batch(messages)
+      resp = sqs.delete_message_batch({
+        queue_url: queue,
+        entries: format_messages_for_deletion(messages)
+      })
+
+      if resp.successful.size != messages.size
+        logger.error("Filtered out messages couldn't get deleted for #{queue}")
+        resp.failed.each do |failed_message|
+          logger.error("Message #{failed_message.id} wasn't deleted: #{failed_message.message}")
+        end
+      end
+    end
+
+    def format_messages_for_deletion(messages)
+      messages.map do |message|
+        {
+          id: message.id,
+          receipt_handle: message.receipt_handle
+        }
+      end
     end
 
     def logger

--- a/lib/circuitry/version.rb
+++ b/lib/circuitry/version.rb
@@ -1,3 +1,3 @@
 module Circuitry
-  VERSION = '3.5.0'
+  VERSION = '3.6.0'
 end


### PR DESCRIPTION
We found a bug with our filtering logic that is detailed in [Circuitry Filtering Doesn't Delete Messages in Queue](https://www.pivotaltracker.com/story/show/178901763)

The work done here makes sure that we have a step where we are able to delete messages that would be filtered out in batch only if filtered out messages exist

Logged errors would pop up on Datadog as that's how we have the logger on bigmaven