### PR TITLE
Reinstate `auto_delete` and `before_message` options and `#delete_messages` for Subscriber

### DIFF
--- a/lib/circuitry/subscriber.rb
+++ b/lib/circuitry/subscriber.rb
@@ -70,6 +70,11 @@ module Circuitry
       Circuitry.subscriber_config.async_strategy
     end
 
+    def delete_messages(message_entries)
+      logger.info("Removing messages [#{message_entries.map { |entry| entry[:id] }.join(', ') }] from queue")
+      sqs.delete_message_batch(queue_url: queue, entries: message_entries)
+    end
+
     protected
 
     attr_writer :queue, :timeout, :wait_time, :batch_size, :ignore_visibility_timeout, :filter_with, :before_message, :auto_delete

--- a/spec/circuitry/subscriber_spec.rb
+++ b/spec/circuitry/subscriber_spec.rb
@@ -319,6 +319,36 @@ RSpec.describe Circuitry::Subscriber, type: :model do
               subject.subscribe(&block)
             end
           end
+
+          describe 'before_message' do
+            let(:messages) {
+              double('Aws::SQS::Types::Message', message_id: 'one', receipt_handle: 'delete-one', body: { 'Message' => 'Foo'.to_json, 'TopicArn' => 'arn:aws:sns:us-east-1:123456789012:test-event-task-changed' }.to_json)
+            }
+            let(:options) { { before_message: before_message } }
+
+            let(:before_message) do
+              lambda do |_message|
+                expect(@expected_messages).to eq([])
+                @expected_messages << 'before_message was called'
+              end
+            end
+
+            let(:block) do
+              ->(_, _) do
+                expect(@expected_messages).to eq(['before_message was called'])
+                @expected_messages << 'subscribe block was called'
+              end
+            end
+
+            before do
+              @expected_messages = []
+            end
+
+            it 'calls the before_message handler before processing the messages' do
+              subject.subscribe(&block)
+              expect(@expected_messages).to eq(['before_message was called', 'subscribe block was called'])
+            end
+          end
         end
 
         describe 'synchronously' do


### PR DESCRIPTION
References: https://github.com/mavenlink/circuitry/pull/16

### Description
- Adds `auto_delete` option that:
  - defaults to true
  - allows SQS message to be deleted
  - if false will call the subscriber's block with a third `message_entry` argument
    - This is used for bulk deleting of messages from sqs
- Adds `before_message` option that will take a block to be executed prior to the subscriber's block
- Adds `#delete_messages` that bulk removes a set of messages from SQS, given a list of message_entries

### Task 
In service of https://github.com/mavenlink/audit-logs/pull/200